### PR TITLE
fix register macros for documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
+## :pizza: v0.4.1
+  - ### :detective: Fixes
+    - Fix issue that only single line comments were allowed in ``define_mmio_register!`` macro expansion
+    
 ## :pizza: v0.4.0
   - ### :bulb: Features
     1. Enable MMIO register definitions to set visibility in defining crate.<br>

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,15 +1,15 @@
 [package]
 name = "ruspiro-register"
 authors = ["André Borrmann <pspwizard@gmx.de>"]
-version = "0.4.0" # remember to update html_root_url
+version = "0.4.1" # remember to update html_root_url
 description = """
 The crate provides simple to use macros to define MMIO registers representations allowing safe access to their contents.
 In addition this crate defines specific aarch64 and aarch32(CP15) registers to safely use them in rust code. This
 reduces the need of 'unsafe' calls.
 """
 license = "Apache-2.0"
-repository = "https://github.com/RusPiRo/ruspiro-register/tree/v0.4.0"
-documentation = "https://docs.rs/ruspiro-register/0.4.0"
+repository = "https://github.com/RusPiRo/ruspiro-register/tree/v0.4.1"
+documentation = "https://docs.rs/ruspiro-register/0.4.1"
 readme = "README.md"
 keywords = ["RusPiRo", "register", "raspberrypi", "baremetal", "mmio"]
 categories = ["no-std", "embedded"]

--- a/makefile
+++ b/makefile
@@ -30,6 +30,14 @@ doc: export AR = aarch64-elf-ar.exe
 doc:
 	# build docu for this crate using custom target
 	cargo doc --no-deps --target aarch64-unknown-linux-gnu --release --open
-	
+
+clippy: export CFLAGS = -march=armv8-a -Wall -O3 -nostdlib -nostartfiles -ffreestanding -mtune=cortex-a53
+clippy: export RUSTFLAGS = -C linker=aarch64-elf-gcc.exe -C target-cpu=cortex-a53 -C target-feature=+strict-align,+a53,+fp-armv8,+neon -C link-arg=-nostartfiles -C opt-level=3 -C debuginfo=0
+clippy: export CC = aarch64-elf-gcc.exe
+clippy: export AR = aarch64-elf-ar.exe
+clippy:
+	# run clippy for this crate using custom target
+	cargo xclippy --target aarch64-unknown-linux-gnu
+
 clean:
 	cargo clean

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,7 @@
  * Author: André Borrmann
  * License: Apache License 2.0
  **********************************************************************************************************************/
-#![doc(html_root_url = "https://docs.rs/ruspiro-register/0.4.0")]
+#![doc(html_root_url = "https://docs.rs/ruspiro-register/0.4.1")]
 #![no_std]
 #![feature(asm, const_fn, doc_cfg)]
 
@@ -29,7 +29,7 @@
 //!         sctlr_el1::I::ENABLE   // instruction cache
 //!     );
 //! }
-//! 
+//!
 //! #[cfg(target_arch="arm")]
 //! fn enable_mmu() {
 //!     // update the system control register in aarch32 to enable caching and the MMU

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -93,10 +93,12 @@ macro_rules! register_field_values {
 /// # use ruspiro_register::*;
 /// define_mmio_register!(
 ///     /// A MMIO Register FOO
+///     /// Defines as Read/Write register
 ///     FOO<ReadWrite<u32>@(0x3F20_0000)> {
 ///         /// This is a register field BAR
 ///         BAR OFFSET(3) BITS(3),
-///         /// This is a register field BAZ with enum like field values
+///         /// This is a register field BAZ.
+///         /// It contains enum like field value definitions
 ///         BAZ OFFSET(6) BITS(3) [
 ///             /// This is a value of the register field
 ///             VAL1 = 0b000,
@@ -129,11 +131,11 @@ macro_rules! register_field_values {
 #[macro_export]
 macro_rules! define_mmio_register {
     // REGISTER_NAME<ReadWrite<TYPE>@ADDRESS> { FIELD OFFSET(num) BITS(num) [ VALUE: val ] }
-    ($($(#[doc = $rdoc:expr])? $vis:vis $name:ident<$access:ident<$t:ty>@($addr:expr)> $(
+    ($($(#[doc = $rdoc:expr])* $vis:vis $name:ident<$access:ident<$t:ty>@($addr:expr)> $(
         { $(
-                $(#[doc = $fdoc:expr])?
+                $(#[doc = $fdoc:expr])*
                 $field:ident OFFSET($offset:literal) $(BITS($bits:literal))?
-                $([$($(#[doc = $fvdoc:expr])? $enum:ident = $value:expr),*])?
+                $([$($(#[doc = $fvdoc:expr])* $enum:ident = $value:expr),*])?
         ),* }
     )?),*) => {
         $(
@@ -142,11 +144,11 @@ macro_rules! define_mmio_register {
             $vis mod $name {
                 use $crate::*;
                 use super::*;
-                $(#[doc = $rdoc])?
+                $(#[doc = $rdoc])*
                 pub const Register: $access<$t> = $access::<$t>::new($addr);
                 $(
                     $(
-                        $(#[doc = $fdoc])?
+                        $(#[doc = $fdoc])*
                         $crate::register_field!($t, $field, $offset $(, $bits)?);
                         pub mod $field {
                             use super::*;
@@ -157,7 +159,7 @@ macro_rules! define_mmio_register {
                                 RegisterFieldValue::<$t>::new($field, value)
                             }
                             $(
-                                $crate::register_field_values!($field, $t, $($($fvdoc)?, $enum = $value),*);
+                                $crate::register_field_values!($field, $t, $($($fvdoc)*, $enum = $value),*);
                             )*
                         }
                     )*

--- a/src/system/mod.rs
+++ b/src/system/mod.rs
@@ -41,5 +41,11 @@ pub fn isb() {
 /// assembly DSB instruction
 #[inline(always)]
 pub fn dsb() {
-    unsafe { asm!("dsb") };
+    unsafe { asm!("dsb sy") };
+}
+
+/// assembly DSB instruction
+#[inline(always)]
+pub fn dmb() {
+    unsafe { asm!("dmb sy") };
 }


### PR DESCRIPTION
Adjust register definition macros to support multi-line documentation on elements and field values