### PR TITLE
fix doc generation on doc.rs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## :peach: v0.5.2
+
+- ### :wrench: Maintenance
+
+  - fix issue generating the documentation at doc.rs which failes with a custom build target. So fall-back at docu generation to the standard target `aarch64-unknown-linux-gnu`
+  
 ## :peach: v0.5.1
 
 This is mainly a maintenance version migrating the build pipeline to GitHub Actions.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ruspiro-register"
 authors = ["André Borrmann <pspwizard@gmx.de>"]
-version = "0.5.1" # remember to update html_root_url in lib.rs
+version = "0.5.2" # remember to update html_root_url in lib.rs
 description = """
 The crate provides the definitions to conviniently work with register field values that are typically presented by a set of bit fields.
 """
@@ -31,8 +31,9 @@ is-it-maintained-open-issues = { repository = "RusPiRo/ruspiro-register" }
 # of this crate is recommended - example:
 # ruspiro-dummy = "0.4"
 
-[features]
-ruspiro_pi3 = [ ]
+[package.metadata.docs.rs]
+targets = ["aarch64-unknown-linux-gnu"]
+features = []
 
 [patch.crates-io]
 # we require an entry for each dependent RUSPIRO crate here

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -21,21 +21,21 @@ command = "cargo"
 args = ["build", "--release", "--features", "${FEATURES}"]
 
 [tasks.pi3]
-env = { FEATURES = "ruspiro_pi3" }
+env = { FEATURES = "" }
 run_task = "build"
 
 [tasks.clippy]
-env = { FEATURES = "ruspiro_pi3" }
+env = { FEATURES = "" }
 command = "cargo"
 args = ["clippy", "--features", "${FEATURES}"]
 
 [tasks.doc]
-env = { FEATURES = "ruspiro_pi3" }
+env = { FEATURES = "" }
 command = "cargo"
-args = ["doc", "--open", "--features", "${FEATURES}"]
+args = ["doc", "--target", "aarch64-unknown-linux-gnu", "--open", "--features", "${FEATURES}"]
 
 [tasks.doctest]
-env = { FEATURES = "ruspiro_pi3" }
+env = { FEATURES = "" }
 command = "cargo"
 args = ["test", "--doc", "--features", "${FEATURES}"]
 


### PR DESCRIPTION
doc.rs does only compile the documentation with known build targets.
Thus the build with the custom target fails. Fis this by passing a standard build target to the doc generation.