### PR TITLE
another attempt to fix crates.io docu generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## :peach: v0.5.4
+
+- ### :wrench: Maintenance
+
+  - fix issue generating the documentation at doc.rs which failes with a custom build target. So fall-back at docu generation to the standard target `aarch64-unknown-linux-gnu` and do not include the `.cargo/config.toml` when pushing to crates.io as this is not needed if the crate is used as a dependency and seem to lead to the doc generation issue even though a specific target was choosen in the `Cargo.toml` file for the doc.
+
 ## :peach: v0.5.3
 
 - ### :wrench: Maintenance

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ruspiro-register"
 authors = ["André Borrmann <pspwizard@gmx.de>"]
-version = "0.5.3" # remember to update html_root_url in lib.rs
+version = "0.5.4" # remember to update html_root_url in lib.rs
 description = """
 The crate provides the definitions to conviniently work with register field values that are typically presented by a set of bit fields.
 """
@@ -12,7 +12,7 @@ documentation = "https://docs.rs/ruspiro-register/||VERSION||"
 categories = ["no-std", "embedded"]
 keywords = ["ruspiro", "register", "registerfields"]
 edition = "2018"
-exclude = ["Makefile.toml"]
+exclude = ["Makefile.toml", ".cargo/config.toml"]
 
 [badges]
 maintenance = { status = "actively-developed" }


### PR DESCRIPTION
This time do not publish the `.cargo/config.toml` to crates.io to fix the doc generation issue.